### PR TITLE
add process status

### DIFF
--- a/example/build.ts
+++ b/example/build.ts
@@ -9,8 +9,8 @@ async function build(source: string) {
   	sveltePath: "https://esm.sh/svelte",
   });
   await Deno.writeTextFile("./compiled.js", compiledDom.js.code);
-  await Deno.run({ cmd: "denopack -i ./main.ts -o ./build.js".split(" ") });
-
+  const p = Deno.run({ cmd: "denopack -i ./main.ts --output ./build.js".split(" ") });    
+  console.log(await p.status()) // { success: true } | { success: false }
 }
 
 await build(Deno.args[0]);


### PR DESCRIPTION
Add process status to the example so the user can see success or failure

When I was running this, it failed many times but I could not see why. Adding the output will show the user success or failure

ref: 
https://doc.deno.land/https/github.com/denoland/deno/releases/latest/download/lib.deno.d.ts#Deno.run
